### PR TITLE
Add setup script and expand CLI flags

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+pip install -e codex_py[dev]

--- a/codex_py/agent_loop.py
+++ b/codex_py/agent_loop.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+import time
+from typing import Any, Callable, Dict, Iterable, List, Optional
+
+try:
+    import openai
+except Exception:  # pragma: no cover - openai optional
+    openai = None
+
+
+class AgentLoop:
+    def __init__(
+        self,
+        model: str,
+        api_key: str | None,
+        instructions: str = "",
+        on_item: Callable[[Dict[str, Any]], None] | None = None,
+        on_loading: Callable[[bool], None] | None = None,
+        on_command: Callable[[List[str]], bool] | None = None,
+        max_retries: int = 3,
+    ) -> None:
+        self.model = model
+        self.api_key = api_key
+        self.instructions = instructions
+        self.on_item = on_item or (lambda item: None)
+        self.on_loading = on_loading or (lambda b: None)
+        self.on_command = on_command or (lambda cmd: True)
+        self.max_retries = max_retries
+
+    def run(self, messages: List[Dict[str, str]]) -> None:
+        if openai is None:
+            raise RuntimeError("openai package required")
+        client = openai.OpenAI(api_key=self.api_key) if hasattr(openai, "OpenAI") else openai
+        attempt = 0
+        while attempt <= self.max_retries:
+            attempt += 1
+            try:
+                stream = client.chat.completions.create(
+                    model=self.model,
+                    messages=messages,
+                    stream=True,
+                )
+                self.on_loading(True)
+                for chunk in stream:
+                    if isinstance(chunk, dict) and "tool_calls" in chunk.get("choices", [{}])[0].get("delta", {}):
+                        tool = chunk["choices"][0]["delta"]["tool_calls"][0]
+                        if tool.get("name") == "shell":
+                            command = tool["arguments"].get("command", "")
+                            parts = command.split()
+                            if not self.on_command(parts):
+                                return
+                    self.on_item(chunk)
+                self.on_loading(False)
+                return
+            except Exception as e:
+                if attempt > self.max_retries:
+                    raise
+                time.sleep(0.5 * attempt)

--- a/codex_py/approvals.py
+++ b/codex_py/approvals.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+import os
+import shlex
+
+ApprovalPolicy = str  # 'suggest', 'auto-edit', 'full-auto'
+
+@dataclass
+class SafetyAssessment:
+    type: str
+    reason: Optional[str] = None
+    group: Optional[str] = None
+    run_in_sandbox: bool = False
+
+
+SAFE_COMMANDS = {
+    "cd": ("Change directory", "Navigating"),
+    "ls": ("List directory", "Searching"),
+    "pwd": ("Print working directory", "Navigating"),
+    "true": ("No-op", "Utility"),
+    "echo": ("Echo string", "Printing"),
+    "cat": ("View file contents", "Reading files"),
+    "nl": ("View file with line numbers", "Reading files"),
+    "rg": ("Ripgrep search", "Searching"),
+    "grep": ("Text search", "Searching"),
+    "head": ("Show file head", "Reading files"),
+    "tail": ("Show file tail", "Reading files"),
+    "wc": ("Word count", "Reading files"),
+    "which": ("Locate command", "Searching"),
+}
+
+
+def is_safe_command(cmd: List[str]) -> Optional[Tuple[str, str]]:
+    info = SAFE_COMMANDS.get(cmd[0])
+    if info:
+        return info
+    if cmd[0] == "git" and len(cmd) > 1:
+        sub = cmd[1]
+        if sub in {"status", "branch", "log", "diff", "show"}:
+            return (f"Git {sub}", "Using git")
+    if cmd[0] == "cargo" and len(cmd) > 1 and cmd[1] == "check":
+        return ("Cargo check", "Running command")
+    if cmd[0] == "find":
+        unsafe = {"-exec", "-execdir", "-ok", "-okdir", "-delete", "-fls", "-fprint", "-fprint0", "-fprintf"}
+        if any(arg in unsafe for arg in cmd):
+            return None
+        return ("Find files", "Searching")
+    if cmd[0] == "sed" and len(cmd) >= 3 and cmd[1] == "-n" and _valid_sed_n(cmd[2]):
+        return ("Sed print subset", "Reading files")
+    return None
+
+
+def _valid_sed_n(arg: str) -> bool:
+    import re
+    return bool(re.match(r"^(\d+,)?\d+p$", arg or ""))
+
+
+def can_auto_approve(command: List[str], policy: ApprovalPolicy) -> SafetyAssessment:
+    safe = is_safe_command(command)
+    if safe:
+        reason, group = safe
+        return SafetyAssessment(type="auto-approve", reason=reason, group=group)
+    if policy == "full-auto":
+        return SafetyAssessment(
+            type="auto-approve",
+            reason="Full auto mode",
+            group="Running commands",
+            run_in_sandbox=True,
+        )
+    return SafetyAssessment(type="ask-user")

--- a/codex_py/cli.py
+++ b/codex_py/cli.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+import json
+import os
+import pathlib
+import typer
+import webbrowser
+import http.server
+import socketserver
+from typing import Optional
+from .tui import HistoryApp, ReviewApp
+
+from .config import load_config
+from .agent_loop import AgentLoop
+from .approvals import can_auto_approve
+
+app = typer.Typer(add_help_option=False)
+
+
+def login_flow() -> str:
+    token = "dummy-token"
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.end_headers()
+            self.wfile.write(b"Logged in")
+            nonlocal token
+            token = self.path.split("token=")[-1]
+
+    with socketserver.TCPServer(("", 0), Handler) as httpd:
+        port = httpd.server_address[1]
+        url = f"http://localhost:{port}"
+        webbrowser.open(url)
+        httpd.handle_request()
+    return token
+
+
+@app.callback()
+def main(
+    prompt: Optional[str] = typer.Argument(None, help="Prompt"),
+    model: Optional[str] = typer.Option(None, "-m", "--model"),
+    provider: Optional[str] = typer.Option(None, "-p", "--provider"),
+    view: Optional[str] = typer.Option(None, "-v", "--view"),
+    history: bool = typer.Option(False, "--history", help="Browse history"),
+    login: bool = typer.Option(False, "--login", help="Login to Codex"),
+    quiet: bool = typer.Option(False, "-q", "--quiet", help="Quiet mode"),
+    full_context: bool = typer.Option(False, "-f", "--full-context", help="Use larger model"),
+    auto_edit: bool = typer.Option(False, "--auto-edit", help="Automatically approve edits"),
+    full_auto: bool = typer.Option(False, "--full-auto", help="Run without confirmations"),
+    approval_mode: str = typer.Option("suggest", "--approval-mode", help="Approval policy"),
+    image: Optional[str] = typer.Option(None, "--image", help="Image prompt"),
+):
+    """Codex Python CLI"""
+    config = load_config(is_full_context=full_context)
+    if model:
+        config["model"] = model
+    if provider:
+        config["provider"] = provider
+
+    api_key = os.environ.get("OPENAI_API_KEY", "")
+    if login or not api_key:
+        api_key = login_flow()
+        os.environ["OPENAI_API_KEY"] = api_key
+        (pathlib.Path.home() / ".codex" / "auth.json").write_text(
+            json.dumps({"OPENAI_API_KEY": api_key})
+        )
+
+    if view:
+        path = pathlib.Path(view)
+        typer.echo(path.read_text())
+        raise typer.Exit()
+
+    if history:
+        history_dir = pathlib.Path.home() / ".codex" / "history"
+        if history_dir.exists():
+            content = HistoryApp.run(history_dir)
+            if content:
+                typer.echo(content)
+        raise typer.Exit()
+
+    if not prompt:
+        typer.echo("No prompt supplied", err=True)
+        raise typer.Exit(1)
+
+    buffer = []
+
+    def on_item(it):
+        if quiet:
+            if isinstance(it, dict) and "choices" in it:
+                content = it["choices"][0]["delta"].get("content")
+                if content:
+                    buffer.append(content)
+        else:
+            typer.echo(json.dumps(it))
+
+    # simple approval handling
+    def on_command(command: list[str]) -> bool:
+        mode = "full-auto" if full_auto else "auto-edit" if auto_edit else approval_mode
+        assessment = can_auto_approve(command, mode)
+        if assessment.type == "auto-approve":
+            return True
+        result = ReviewApp.run(command)
+        return result == "yes"
+
+    agent = AgentLoop(model=config["model"], api_key=api_key, instructions=config.get("instructions", ""), on_item=on_item, on_command=on_command)
+    messages = [{"role": "user", "content": prompt}]
+    if image:
+        try:
+            import base64
+            data = pathlib.Path(image).read_bytes()
+            b64 = base64.b64encode(data).decode()
+            messages.append({"role": "user", "image": b64})
+        except Exception:
+            pass
+    agent.run(messages)
+    if quiet:
+        typer.echo("".join(buffer))
+

--- a/codex_py/config.py
+++ b/codex_py/config.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+CONFIG_DIR = Path.home() / ".codex"
+CONFIG_JSON_FILEPATH = CONFIG_DIR / "config.json"
+CONFIG_YAML_FILEPATH = CONFIG_DIR / "config.yaml"
+CONFIG_YML_FILEPATH = CONFIG_DIR / "config.yml"
+INSTRUCTIONS_FILEPATH = CONFIG_DIR / "instructions.md"
+
+DEFAULT_AGENTIC_MODEL = "codex-mini-latest"
+DEFAULT_FULL_CONTEXT_MODEL = "gpt-4.1"
+
+
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    try:
+        import yaml
+    except Exception:
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    except Exception:
+        return {}
+
+
+EMPTY_STORED_CONFIG = {"model": ""}
+
+
+class AppConfig(Dict[str, Any]):
+    pass
+
+
+def load_config(
+    config_path: Path | None = None,
+    instructions_path: Path | None = None,
+    *,
+    is_full_context: bool = False,
+) -> AppConfig:
+    config_path = config_path or CONFIG_JSON_FILEPATH
+    if not config_path.exists():
+        if config_path == CONFIG_JSON_FILEPATH:
+            if CONFIG_YAML_FILEPATH.exists():
+                config_path = CONFIG_YAML_FILEPATH
+            elif CONFIG_YML_FILEPATH.exists():
+                config_path = CONFIG_YML_FILEPATH
+    stored: Dict[str, Any] = {}
+    if config_path.exists():
+        ext = config_path.suffix.lower()
+        try:
+            if ext in {".yaml", ".yml"}:
+                stored = _load_yaml(config_path)
+            else:
+                stored = json.loads(config_path.read_text("utf-8"))
+        except Exception:
+            stored = {}
+    instructions_path = instructions_path or INSTRUCTIONS_FILEPATH
+    instructions = instructions_path.read_text("utf-8") if instructions_path.exists() else ""
+    model = (stored.get("model") or "").strip() or (
+        DEFAULT_FULL_CONTEXT_MODEL if is_full_context else DEFAULT_AGENTIC_MODEL
+    )
+    cfg: AppConfig = AppConfig(
+        model=model,
+        provider=stored.get("provider"),
+        instructions=instructions,
+    )
+    cfg.update(stored)
+
+    # bootstrap minimal config on first run
+    if not config_path.exists():
+        try:
+            config_path.parent.mkdir(parents=True, exist_ok=True)
+            if config_path.suffix.lower() in {".yaml", ".yml"}:
+                try:
+                    import yaml
+                except Exception:
+                    config_path.write_text(json.dumps(EMPTY_STORED_CONFIG, indent=2), "utf-8")
+                else:
+                    config_path.write_text(yaml.safe_dump(EMPTY_STORED_CONFIG), "utf-8")
+            else:
+                config_path.write_text(json.dumps(EMPTY_STORED_CONFIG, indent=2), "utf-8")
+        except Exception:
+            pass
+    if not instructions_path.exists():
+        try:
+            instructions_path.parent.mkdir(parents=True, exist_ok=True)
+            instructions_path.write_text(instructions, "utf-8")
+        except Exception:
+            pass
+    return cfg

--- a/codex_py/pyproject.toml
+++ b/codex_py/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "codex_py"
+version = "0.1.0"
+description = "Codex Python CLI"
+authors = [{name = "OpenAI"}]
+requires-python = ">=3.9"
+
+[project.dependencies]
+typer = "^0.9"
+openai = "^1.3"
+textual = "^0.51"
+
+[project.optional-dependencies.dev]
+pytest = "^7.4"
+
+[project.scripts]
+codex = "codex_py.cli:app"
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/codex_py/tests/test_agent.py
+++ b/codex_py/tests/test_agent.py
@@ -1,0 +1,24 @@
+from codex_py.agent_loop import AgentLoop
+
+
+class DummyStream(list):
+    def __iter__(self):
+        yield {"choices": [{"delta": {"content": "hi"}}]}
+
+
+class DummyClient:
+    def __init__(self):
+        self.chat = self
+        self.completions = self
+
+    def create(self, model, messages, stream):
+        return DummyStream()
+
+
+def test_agent_basic(monkeypatch):
+    import codex_py.agent_loop as ag
+    monkeypatch.setattr(ag, "openai", type("x", (), {"OpenAI": lambda api_key=None: DummyClient()}))
+    items = []
+    agent = AgentLoop("test", api_key="key", on_item=items.append)
+    agent.run([{"role": "user", "content": "hi"}])
+    assert items

--- a/codex_py/tests/test_cli.py
+++ b/codex_py/tests/test_cli.py
@@ -1,0 +1,31 @@
+import json
+import os
+from typer.testing import CliRunner
+
+from codex_py.cli import app
+
+runner = CliRunner()
+
+def test_help():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "Codex Python CLI" in result.output
+
+def test_view(tmp_path):
+    file = tmp_path / "rollout.json"
+    file.write_text("hello")
+    result = runner.invoke(app, ["--view", str(file)])
+    assert result.exit_code == 0
+    assert "hello" in result.output
+
+def test_quiet_collect(monkeypatch):
+    from codex_py.agent_loop import AgentLoop
+
+    class Dummy(AgentLoop):
+        def run(self, messages):
+            self.on_item({"choices": [{"delta": {"content": "hi"}}]})
+
+    monkeypatch.setattr("codex_py.cli.AgentLoop", Dummy)
+    result = runner.invoke(app, ["-q", "hi"])
+    assert result.exit_code == 0
+    assert result.output.strip() == "hi"

--- a/codex_py/tui.py
+++ b/codex_py/tui.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+import json
+from pathlib import Path
+from textual.app import App, ComposeResult
+from textual.widgets import Static
+
+
+class HistoryApp(App[str]):
+    def __init__(self, history_dir: Path) -> None:
+        super().__init__()
+        self.history_dir = history_dir
+        self.selection: str | None = None
+
+    def compose(self) -> ComposeResult:
+        for p in sorted(self.history_dir.glob("*.json")):
+            yield Static(p.name)
+
+    def on_key(self, event) -> None:  # type: ignore
+        if event.key == "q":
+            self.exit(None)
+        if event.key == "enter":
+            focused = self.focused
+            if isinstance(focused, Static):
+                self.exit((self.history_dir / focused.renderable).read_text())
+
+
+class ReviewApp(App[str]):
+    def __init__(self, command: list[str]) -> None:
+        super().__init__()
+        self.command = command
+        self.result = "no"
+
+    def compose(self) -> ComposeResult:
+        yield Static("Run command: " + " ".join(self.command))
+        yield Static("[y]es/[n]o")
+
+    def on_key(self, event) -> None:  # type: ignore
+        if event.key.lower() == "y":
+            self.exit("yes")
+        if event.key.lower() == "n":
+            self.exit("no")


### PR DESCRIPTION
## Summary
- define package dependencies in `pyproject.toml`
- add `.codex/setup.sh` for installing test requirements
- extend CLI with additional flags and quiet mode buffering
- support simple tool command handling in `AgentLoop`
- test quiet mode output

## Testing
- `pytest -q codex_py/tests` *(fails: typer and other deps not installed)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.