### PR TITLE
Fix codex_py tests and CLI

### DIFF
--- a/codex_py/cli.py
+++ b/codex_py/cli.py
@@ -13,7 +13,7 @@ from .config import load_config
 from .agent_loop import AgentLoop
 from .approvals import can_auto_approve
 
-app = typer.Typer(add_help_option=False)
+app = typer.Typer(invoke_without_command=True)
 
 
 def login_flow() -> str:
@@ -54,14 +54,6 @@ def main(
     if provider:
         config["provider"] = provider
 
-    api_key = os.environ.get("OPENAI_API_KEY", "")
-    if login or not api_key:
-        api_key = login_flow()
-        os.environ["OPENAI_API_KEY"] = api_key
-        (pathlib.Path.home() / ".codex" / "auth.json").write_text(
-            json.dumps({"OPENAI_API_KEY": api_key})
-        )
-
     if view:
         path = pathlib.Path(view)
         typer.echo(path.read_text())
@@ -74,6 +66,14 @@ def main(
             if content:
                 typer.echo(content)
         raise typer.Exit()
+
+    api_key = os.environ.get("OPENAI_API_KEY", "")
+    if login or not api_key:
+        api_key = login_flow()
+        os.environ["OPENAI_API_KEY"] = api_key
+        (pathlib.Path.home() / ".codex" / "auth.json").write_text(
+            json.dumps({"OPENAI_API_KEY": api_key})
+        )
 
     if not prompt:
         typer.echo("No prompt supplied", err=True)

--- a/codex_py/tests/conftest.py
+++ b/codex_py/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on sys.path when tests are run from outside
+# tests/ is inside codex_py/, so we need the repository root two levels up
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/codex_py/tui.py
+++ b/codex_py/tui.py
@@ -1,41 +1,62 @@
 from __future__ import annotations
 import json
 from pathlib import Path
-from textual.app import App, ComposeResult
-from textual.widgets import Static
+try:
+    from textual.app import App, ComposeResult
+    from textual.widgets import Static
+    TEXTUAL_AVAILABLE = True
+except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    TEXTUAL_AVAILABLE = False
+
+    class _Stub:
+        def __init__(self, *args, **kwargs) -> None:
+            raise RuntimeError("textual package required")
+
+    App = _Stub  # type: ignore
+    ComposeResult = object  # type: ignore
+    Static = _Stub  # type: ignore
 
 
-class HistoryApp(App[str]):
-    def __init__(self, history_dir: Path) -> None:
-        super().__init__()
-        self.history_dir = history_dir
-        self.selection: str | None = None
+if TEXTUAL_AVAILABLE:
+    class HistoryApp(App[str]):
+        def __init__(self, history_dir: Path) -> None:
+            super().__init__()
+            self.history_dir = history_dir
+            self.selection: str | None = None
 
-    def compose(self) -> ComposeResult:
-        for p in sorted(self.history_dir.glob("*.json")):
-            yield Static(p.name)
+        def compose(self) -> ComposeResult:
+            for p in sorted(self.history_dir.glob("*.json")):
+                yield Static(p.name)
 
-    def on_key(self, event) -> None:  # type: ignore
-        if event.key == "q":
-            self.exit(None)
-        if event.key == "enter":
-            focused = self.focused
-            if isinstance(focused, Static):
-                self.exit((self.history_dir / focused.renderable).read_text())
+        def on_key(self, event) -> None:  # type: ignore
+            if event.key == "q":
+                self.exit(None)
+            if event.key == "enter":
+                focused = self.focused
+                if isinstance(focused, Static):
+                    self.exit((self.history_dir / focused.renderable).read_text())
 
 
-class ReviewApp(App[str]):
-    def __init__(self, command: list[str]) -> None:
-        super().__init__()
-        self.command = command
-        self.result = "no"
+    class ReviewApp(App[str]):
+        def __init__(self, command: list[str]) -> None:
+            super().__init__()
+            self.command = command
+            self.result = "no"
 
-    def compose(self) -> ComposeResult:
-        yield Static("Run command: " + " ".join(self.command))
-        yield Static("[y]es/[n]o")
+        def compose(self) -> ComposeResult:
+            yield Static("Run command: " + " ".join(self.command))
+            yield Static("[y]es/[n]o")
 
-    def on_key(self, event) -> None:  # type: ignore
-        if event.key.lower() == "y":
-            self.exit("yes")
-        if event.key.lower() == "n":
-            self.exit("no")
+        def on_key(self, event) -> None:  # type: ignore
+            if event.key.lower() == "y":
+                self.exit("yes")
+            if event.key.lower() == "n":
+                self.exit("no")
+else:
+    class HistoryApp:
+        def __init__(self, *args, **kwargs) -> None:
+            raise RuntimeError("textual package required")
+
+    class ReviewApp:
+        def __init__(self, *args, **kwargs) -> None:
+            raise RuntimeError("textual package required")


### PR DESCRIPTION
## Summary
- ensure repo root added to Python path for tests
- make `textual` optional in `tui` module
- allow Typer app to run without subcommands and provide default help option
- move `--view` and `--history` handling before login

## Testing
- `pytest codex_py/tests -q`