### PR TITLE
Extend codex_py CLI features

### DIFF
--- a/codex_py/tests/test_cli.py
+++ b/codex_py/tests/test_cli.py
@@ -3,6 +3,8 @@ import os
 from typer.testing import CliRunner
 
 from codex_py.cli import app
+import codex_py.config as cfg
+import subprocess
 
 runner = CliRunner()
 
@@ -17,3 +19,23 @@ def test_view(tmp_path):
     result = runner.invoke(app, ["--view", str(file)])
     assert result.exit_code == 0
     assert "hello" in result.output
+
+
+def test_completion():
+    result = runner.invoke(app, ["--completion", "bash"])
+    assert result.exit_code == 0
+    assert "bash completion for codex" in result.output
+
+
+def test_config_opens_editor(tmp_path, monkeypatch):
+    called = []
+    instr = tmp_path / "instructions.md"
+    monkeypatch.setattr(cfg, "INSTRUCTIONS_FILEPATH", instr)
+    def fake_run(args, *a, **k):
+        called.append(args)
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = runner.invoke(app, ["--config"])
+    assert result.exit_code == 0
+    assert called
+    assert instr.exists()
+


### PR DESCRIPTION
## Summary
- implement `--completion` option for shell completion scripts
- add `--config` option to open instructions file in editor
- update CLI logic to handle new options
- expand tests for completion and config behaviour

## Testing
- `pytest -q codex_py/tests/test_cli.py`
- `npx nx run-many -t test lint --all` *(fails: EHOSTUNREACH)*